### PR TITLE
feat:Add speaker_options object to TranscriptOptionalParams in OpenAPI spec

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.JsonSerializerContextTypes.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.JsonSerializerContextTypes.g.cs
@@ -438,50 +438,54 @@ namespace AssemblyAI
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptParams? Type103 { get; set; }
+        public global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptParamsVariant1? Type104 { get; set; }
+        public global::AssemblyAI.TranscriptParams? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptReadyNotification? Type105 { get; set; }
+        public global::AssemblyAI.TranscriptParamsVariant1? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptReadyStatus? Type106 { get; set; }
+        public global::AssemblyAI.TranscriptReadyNotification? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptWebhookNotification? Type107 { get; set; }
+        public global::AssemblyAI.TranscriptReadyStatus? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.UploadedFile? Type108 { get; set; }
+        public global::AssemblyAI.TranscriptWebhookNotification? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.WordSearchMatch? Type109 { get; set; }
+        public global::AssemblyAI.UploadedFile? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<int>? Type110 { get; set; }
+        public global::AssemblyAI.WordSearchMatch? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<int>>? Type111 { get; set; }
+        public global::System.Collections.Generic.IList<int>? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.WordSearchResponse? Type112 { get; set; }
+        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<int>>? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::AssemblyAI.WordSearchMatch>? Type113 { get; set; }
+        public global::AssemblyAI.WordSearchResponse? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public byte[]? Type114 { get; set; }
+        public global::System.Collections.Generic.IList<global::AssemblyAI.WordSearchMatch>? Type114 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte[]? Type115 { get; set; }
     }
 }

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParams.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParams.g.cs
@@ -221,6 +221,12 @@ namespace AssemblyAI
         public bool? SpeakerLabels { get; set; }
 
         /// <summary>
+        /// Specify options for speaker diarization.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("speaker_options")]
+        public global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? SpeakerOptions { get; set; }
+
+        /// <summary>
         /// Tells the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/models/speaker-diarization) for more details.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("speakers_expected")]
@@ -409,6 +415,9 @@ namespace AssemblyAI
         /// Enable [Speaker diarization](https://www.assemblyai.com/docs/models/speaker-diarization), can be true or false<br/>
         /// Default Value: false
         /// </param>
+        /// <param name="speakerOptions">
+        /// Specify options for speaker diarization.
+        /// </param>
         /// <param name="speakersExpected">
         /// Tells the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/models/speaker-diarization) for more details.
         /// </param>
@@ -476,6 +485,7 @@ namespace AssemblyAI
             object? redactPiiSub,
             bool? sentimentAnalysis,
             bool? speakerLabels,
+            global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? speakerOptions,
             int? speakersExpected,
             object? speechModel,
             float? speechThreshold,
@@ -514,6 +524,7 @@ namespace AssemblyAI
             this.RedactPiiSub = redactPiiSub;
             this.SentimentAnalysis = sentimentAnalysis;
             this.SpeakerLabels = speakerLabels;
+            this.SpeakerOptions = speakerOptions;
             this.SpeakersExpected = speakersExpected;
             this.SpeechModel = speechModel;
             this.SpeechThreshold = speechThreshold;

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsSpeakerOptions.Json.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsSpeakerOptions.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace AssemblyAI
+{
+    public sealed partial class TranscriptOptionalParamsSpeakerOptions
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions),
+                jsonSerializerContext) as global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions),
+                jsonSerializerContext).ConfigureAwait(false)) as global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsSpeakerOptions.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsSpeakerOptions.g.cs
@@ -1,0 +1,62 @@
+
+#nullable enable
+
+namespace AssemblyAI
+{
+    /// <summary>
+    /// Specify options for speaker diarization.
+    /// </summary>
+    public sealed partial class TranscriptOptionalParamsSpeakerOptions
+    {
+        /// <summary>
+        /// &lt;Warning&gt;Setting this parameter too high may hurt model accuracy&lt;/Warning&gt;<br/>
+        /// The maximum number of speakers expected in the audio file.<br/>
+        /// Default Value: 10
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("max_speakers_expected")]
+        public int? MaxSpeakersExpected { get; set; }
+
+        /// <summary>
+        /// The minimum number of speakers expected in the audio file.<br/>
+        /// Default Value: 1
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("min_speakers_expected")]
+        public int? MinSpeakersExpected { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranscriptOptionalParamsSpeakerOptions" /> class.
+        /// </summary>
+        /// <param name="maxSpeakersExpected">
+        /// &lt;Warning&gt;Setting this parameter too high may hurt model accuracy&lt;/Warning&gt;<br/>
+        /// The maximum number of speakers expected in the audio file.<br/>
+        /// Default Value: 10
+        /// </param>
+        /// <param name="minSpeakersExpected">
+        /// The minimum number of speakers expected in the audio file.<br/>
+        /// Default Value: 1
+        /// </param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public TranscriptOptionalParamsSpeakerOptions(
+            int? maxSpeakersExpected,
+            int? minSpeakersExpected)
+        {
+            this.MaxSpeakersExpected = maxSpeakersExpected;
+            this.MinSpeakersExpected = minSpeakersExpected;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranscriptOptionalParamsSpeakerOptions" /> class.
+        /// </summary>
+        public TranscriptOptionalParamsSpeakerOptions()
+        {
+        }
+    }
+}

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -1419,6 +1419,25 @@ components:
           type: [integer, "null"]
           default: null
 
+        speaker_options:
+          x-label: Specify options for speaker diarization.
+          description: Specify options for speaker diarization.
+          type: object
+          additionalProperties: false
+          properties:
+            min_speakers_expected:
+              x-label: Minimum speakers expected
+              description: The minimum number of speakers expected in the audio file.
+              type: integer
+              default: 1
+            max_speakers_expected:
+              x-label: Maximum speakers expected
+              description: |
+                <Warning>Setting this parameter too high may hurt model accuracy</Warning>
+                The maximum number of speakers expected in the audio file.
+              type: integer
+              default: 10
+
         content_safety:
           x-label: Content Moderation
           description: Enable [Content Moderation](https://www.assemblyai.com/docs/models/content-moderation), can be true or false


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new options for configuring speaker diarization, allowing users to specify minimum and maximum expected speakers when generating transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->