### PR TITLE
Add ISpeechToTextClient implementation from Microsoft.Extensions.AI (and fix file upload)

### DIFF
--- a/src/libs/AssemblyAI/AssemblyAI.csproj
+++ b/src/libs/AssemblyAI/AssemblyAI.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.6.2;net8.0;net9.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup Label="Nuget">
@@ -16,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net4.6.2'">

--- a/src/libs/AssemblyAI/Extensions/AssemblyAIClient.SpeechToTextClient.cs
+++ b/src/libs/AssemblyAI/Extensions/AssemblyAIClient.SpeechToTextClient.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using Microsoft.Extensions.AI;
+using System.Runtime.CompilerServices;
+
+namespace AssemblyAI;
+
+public sealed partial class AssemblyAIClient : ISpeechToTextClient
+{
+    private SpeechToTextClientMetadata? _metadata;
+
+    object? ISpeechToTextClient.GetService(Type serviceType, object? serviceKey) =>
+        serviceType is null ? throw new ArgumentNullException(nameof(serviceType)) :
+        serviceKey is not null ? null :
+        serviceType == typeof(SpeechToTextClientMetadata) ? (_metadata ??= new("assemblyai", new Uri(DefaultBaseUrl))) :
+        serviceType.IsInstanceOfType(this) ? this :
+        null;
+
+    /// <inheritdoc />
+    async Task<SpeechToTextResponse> ISpeechToTextClient.GetTextAsync(Stream audioSpeechStream, SpeechToTextOptions? options, CancellationToken cancellationToken)
+    {
+        TranscriptParams? transcriptParams = options?.RawRepresentationFactory?.Invoke(this) is TranscriptParams tmp ? (TranscriptParams?)tmp : null;
+        TranscriptOptionalParams optionalParams = transcriptParams?.Value2 ?? new();
+        optionalParams.LanguageCode ??= options?.SpeechLanguage;
+        optionalParams.SpeechModel ??= options?.ModelId;
+
+        string? audioUrl = transcriptParams?.Value1?.AudioUrl;
+        if (audioUrl is null)
+        {
+            MemoryStream ms = new();
+            await audioSpeechStream.CopyToAsync(ms, 81920, cancellationToken).ConfigureAwait(false);
+            byte[] bytes = ms.ToArray();
+
+            UploadedFile upload = await Transcript.UploadFileAsync(bytes, cancellationToken).ConfigureAwait(false);
+            audioUrl = upload.UploadUrl;
+        }
+
+        Transcript transcript = await Transcript.CreateTranscriptAsync(
+            TranscriptParams.FromUrl(audioUrl, optionalParams),
+            cancellationToken).ConfigureAwait(false);
+
+        string id = transcript.Id.ToString();
+        while (transcript.Status is TranscriptStatus.Queued or TranscriptStatus.Processing)
+        {
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+            transcript = await Transcript.GetTranscriptAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (transcript.Status is TranscriptStatus.Error)
+        {
+            throw new InvalidOperationException(transcript.Error);
+        }
+
+        return new(transcript.Text)
+        {
+            EndTime = transcript.AudioEndAt is int audioEndAt ? TimeSpan.FromMilliseconds(audioEndAt) : null,
+            ModelId = transcript.LanguageModel,
+            RawRepresentation = transcript,
+            ResponseId = id,
+            StartTime = transcript.AudioStartFrom is int audioStartFrom ? TimeSpan.FromMilliseconds(audioStartFrom) : null,
+        };
+    }
+
+    /// <inheritdoc />
+    async IAsyncEnumerable<SpeechToTextResponseUpdate> ISpeechToTextClient.GetStreamingTextAsync(
+        Stream audioSpeechStream, SpeechToTextOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var response = await ((ISpeechToTextClient)this).GetTextAsync(audioSpeechStream, options, cancellationToken).ConfigureAwait(false);
+        foreach (var update in response.ToSpeechToTextResponseUpdates())
+        {
+            yield return update;
+        }
+    }
+}

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.UploadFile.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.UploadFile.g.cs
@@ -68,11 +68,8 @@ namespace AssemblyAI
                     __httpRequest.Headers.Add(__authorization.Name, __authorization.Value);
                 }
             }
-            var __httpRequestContentBody = global::System.Text.Json.JsonSerializer.Serialize(request, request.GetType(), JsonSerializerContext);
-            var __httpRequestContent = new global::System.Net.Http.StringContent(
-                content: __httpRequestContentBody,
-                encoding: global::System.Text.Encoding.UTF8,
-                mediaType: "application/octet-stream");
+            var __httpRequestContent = new global::System.Net.Http.ByteArrayContent(request);
+            __httpRequestContent.Headers.ContentType = new global::System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
             __httpRequest.Content = __httpRequestContent;
 
             PrepareRequest(


### PR DESCRIPTION
File upload was broken. It was uploading a JSON serialized version of the byte array rather than just writing out the bytes as part of an application/octet-stream. I fixed that, and then added an implementation of the ISpeechToTextClient interface from Microsoft.Extensions.AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced speech-to-text functionality, allowing conversion of audio streams to text.
  * Added support for both standard and streaming-like speech-to-text operations with enhanced error handling and optional parameter support.

* **Chores**
  * Updated dependencies and build configuration to improve compatibility and suppress specific build warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->