### PR TITLE
feat:Remove "nano" speech model from SpeechModel enum and OpenAPI documentation

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.SpeechModel.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.SpeechModel.g.cs
@@ -15,10 +15,6 @@ namespace AssemblyAI
         /// <summary>
         /// 
         /// </summary>
-        Nano,
-        /// <summary>
-        /// 
-        /// </summary>
         Slam1,
         /// <summary>
         /// 
@@ -39,7 +35,6 @@ namespace AssemblyAI
             return value switch
             {
                 SpeechModel.Best => "best",
-                SpeechModel.Nano => "nano",
                 SpeechModel.Slam1 => "slam-1",
                 SpeechModel.Universal => "universal",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
@@ -53,7 +48,6 @@ namespace AssemblyAI
             return value switch
             {
                 "best" => SpeechModel.Best,
-                "nano" => SpeechModel.Nano,
                 "slam-1" => SpeechModel.Slam1,
                 "universal" => SpeechModel.Universal,
                 _ => null,

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -2201,7 +2201,6 @@ components:
       x-fern-sdk-group-name: transcripts
       enum:
         - best
-        - nano
         - slam-1
         - universal
       x-fern-enum:
@@ -2214,9 +2213,6 @@ components:
         best:
           name: Best
           description: The model optimized for accuracy, low latency, ease of use, and mutli-language support.
-        nano:
-          name: Nano
-          description: A lightweight, lower cost model for a wide range of languages.
       x-aai-enum:
         best:
           label: Best


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the "nano" speech model option from the list of available speech models in the API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->