### PR TITLE
feat:Add language_detection_options to TranscriptOptionalParams

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.JsonSerializerContextTypes.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.JsonSerializerContextTypes.g.cs
@@ -434,58 +434,62 @@ namespace AssemblyAI
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptOptionalParamsRedactPiiAudioOptions? Type102 { get; set; }
+        public global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions? Type102 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? Type103 { get; set; }
+        public byte[]? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptParams? Type104 { get; set; }
+        public global::AssemblyAI.TranscriptOptionalParamsRedactPiiAudioOptions? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptParamsVariant1? Type105 { get; set; }
+        public global::AssemblyAI.TranscriptOptionalParamsSpeakerOptions? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptReadyNotification? Type106 { get; set; }
+        public global::AssemblyAI.TranscriptParams? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptReadyStatus? Type107 { get; set; }
+        public global::AssemblyAI.TranscriptParamsVariant1? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.TranscriptWebhookNotification? Type108 { get; set; }
+        public global::AssemblyAI.TranscriptReadyNotification? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.UploadedFile? Type109 { get; set; }
+        public global::AssemblyAI.TranscriptReadyStatus? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.WordSearchMatch? Type110 { get; set; }
+        public global::AssemblyAI.TranscriptWebhookNotification? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<int>? Type111 { get; set; }
+        public global::AssemblyAI.UploadedFile? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<int>>? Type112 { get; set; }
+        public global::AssemblyAI.WordSearchMatch? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::AssemblyAI.WordSearchResponse? Type113 { get; set; }
+        public global::System.Collections.Generic.IList<int>? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::AssemblyAI.WordSearchMatch>? Type114 { get; set; }
+        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<int>>? Type114 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public byte[]? Type115 { get; set; }
+        public global::AssemblyAI.WordSearchResponse? Type115 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::System.Collections.Generic.IList<global::AssemblyAI.WordSearchMatch>? Type116 { get; set; }
     }
 }

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParams.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParams.g.cs
@@ -144,6 +144,12 @@ namespace AssemblyAI
         public bool? LanguageDetection { get; set; }
 
         /// <summary>
+        /// Specify options for Automatic Language Detection.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("language_detection_options")]
+        public global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions? LanguageDetectionOptions { get; set; }
+
+        /// <summary>
         /// Enable [Multichannel](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) transcription, can be true or false.<br/>
         /// Default Value: false
         /// </summary>
@@ -377,6 +383,9 @@ namespace AssemblyAI
         /// Enable [Automatic language detection](https://www.assemblyai.com/docs/models/speech-recognition#automatic-language-detection), either true or false.<br/>
         /// Default Value: false
         /// </param>
+        /// <param name="languageDetectionOptions">
+        /// Specify options for Automatic Language Detection.
+        /// </param>
         /// <param name="multichannel">
         /// Enable [Multichannel](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) transcription, can be true or false.<br/>
         /// Default Value: false
@@ -475,6 +484,7 @@ namespace AssemblyAI
             object? languageCode,
             float? languageConfidenceThreshold,
             bool? languageDetection,
+            global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions? languageDetectionOptions,
             bool? multichannel,
             bool? punctuate,
             bool? redactPii,
@@ -514,6 +524,7 @@ namespace AssemblyAI
             this.LanguageCode = languageCode;
             this.LanguageConfidenceThreshold = languageConfidenceThreshold;
             this.LanguageDetection = languageDetection;
+            this.LanguageDetectionOptions = languageDetectionOptions;
             this.Multichannel = multichannel;
             this.Punctuate = punctuate;
             this.RedactPii = redactPii;

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsLanguageDetectionOptions.Json.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsLanguageDetectionOptions.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace AssemblyAI
+{
+    public sealed partial class TranscriptOptionalParamsLanguageDetectionOptions
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions),
+                jsonSerializerContext) as global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions),
+                jsonSerializerContext).ConfigureAwait(false)) as global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::AssemblyAI.TranscriptOptionalParamsLanguageDetectionOptions?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsLanguageDetectionOptions.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.TranscriptOptionalParamsLanguageDetectionOptions.g.cs
@@ -1,0 +1,58 @@
+
+#nullable enable
+
+namespace AssemblyAI
+{
+    /// <summary>
+    /// Specify options for Automatic Language Detection.
+    /// </summary>
+    public sealed partial class TranscriptOptionalParamsLanguageDetectionOptions
+    {
+        /// <summary>
+        /// List of languages expected in the audio file.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expected_languages")]
+        public byte[]? ExpectedLanguages { get; set; }
+
+        /// <summary>
+        /// If the detected language of the audio file is not in the list of expected languages, the `fallback_language` is used. Specify `["auto"]` to let our model choose the fallback language from `expected_languages` with the highest confidence score.<br/>
+        /// Default Value: auto
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("fallback_language")]
+        public string? FallbackLanguage { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranscriptOptionalParamsLanguageDetectionOptions" /> class.
+        /// </summary>
+        /// <param name="expectedLanguages">
+        /// List of languages expected in the audio file.
+        /// </param>
+        /// <param name="fallbackLanguage">
+        /// If the detected language of the audio file is not in the list of expected languages, the `fallback_language` is used. Specify `["auto"]` to let our model choose the fallback language from `expected_languages` with the highest confidence score.<br/>
+        /// Default Value: auto
+        /// </param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public TranscriptOptionalParamsLanguageDetectionOptions(
+            byte[]? expectedLanguages,
+            string? fallbackLanguage)
+        {
+            this.ExpectedLanguages = expectedLanguages;
+            this.FallbackLanguage = fallbackLanguage;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranscriptOptionalParamsLanguageDetectionOptions" /> class.
+        /// </summary>
+        public TranscriptOptionalParamsLanguageDetectionOptions()
+        {
+        }
+    }
+}

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -1253,6 +1253,26 @@ components:
           type: boolean
           default: false
 
+        language_detection_options:
+          x-label: Specify options for Automatic Language Detection.
+          description: Specify options for Automatic Language Detection.
+          type: object
+          additionalProperties: false
+          properties:
+            expected_languages:
+              x-label: Minimum speakers expected
+              description: List of languages expected in the audio file.
+              type: array
+              objects:
+                x-label: language
+                type: string
+            fallback_language:
+              x-label: Fallback language
+              description: |
+                If the detected language of the audio file is not in the list of expected languages, the `fallback_language` is used. Specify `["auto"]` to let our model choose the fallback language from `expected_languages` with the highest confidence score.
+              type: string
+              default: "auto"
+
         language_confidence_threshold:
           x-label: Language confidence threshold
           description: |


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Automatic Language Detection options for transcripts.
  * Specify expected languages to improve detection accuracy.
  * Choose a fallback language when the detected language isn’t in the expected list; defaults to auto-selecting the highest-confidence language.
  * Backward-compatible: existing language detection behavior remains unchanged if options are not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->