### PR TITLE
feat:OpenAPI: max_output_size descriptions reference final_model limits

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.LemurBaseParams.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.LemurBaseParams.g.cs
@@ -35,7 +35,7 @@ namespace AssemblyAI
         public string? InputText { get; set; }
 
         /// <summary>
-        /// Max output size in tokens, up to 4000<br/>
+        /// Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).<br/>
         /// Default Value: 2000
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("max_output_size")]
@@ -78,7 +78,7 @@ namespace AssemblyAI
         /// Use either transcript_ids or input_text as input into LeMUR.
         /// </param>
         /// <param name="maxOutputSize">
-        /// Max output size in tokens, up to 4000<br/>
+        /// Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).<br/>
         /// Default Value: 2000
         /// </param>
         /// <param name="temperature">

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.LemurTaskParamsVariant1.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.LemurTaskParamsVariant1.g.cs
@@ -25,7 +25,7 @@ namespace AssemblyAI
         public string? InputText { get; set; }
 
         /// <summary>
-        /// Max output size in tokens, up to 4000<br/>
+        /// Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).<br/>
         /// Default Value: 2000
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("max_output_size")]
@@ -72,7 +72,7 @@ namespace AssemblyAI
         /// Use either transcript_ids or input_text as input into LeMUR.
         /// </param>
         /// <param name="maxOutputSize">
-        /// Max output size in tokens, up to 4000<br/>
+        /// Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).<br/>
         /// Default Value: 2000
         /// </param>
         /// <param name="prompt">

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -5610,7 +5610,7 @@ components:
           x-go-type: LeMURModel
         max_output_size:
           x-label: Maximum output size
-          description: Max output size in tokens, up to 4000
+          description: Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).
           type: integer
           default: 2000
         temperature:
@@ -5674,7 +5674,7 @@ components:
                 - $ref: "#/components/schemas/LemurModel"
             max_output_size:
               x-label: Maximum output size
-              description: Max output size in tokens, up to 4000
+              description: Maximum output size in tokens, up to the `final_model`'s max [(see chart)](/docs/lemur/customize-parameters#change-the-maximum-output-size).
               type: integer
               default: 2000
             temperature:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Clarified the max output size description to reflect dynamic limits based on the selected model, replacing the fixed 4000-token cap.
  * Added a link to a chart detailing model-specific maximums for easier configuration.
  * Text-only update; no changes to behavior, defaults, or types.
  * Improves accuracy and consistency of public API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->