### PR TITLE
feat:Remove warning from OpenAPI description of redacted audio endpoint

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.ITranscriptClient.GetRedactedAudio.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.ITranscriptClient.GetRedactedAudio.g.cs
@@ -6,7 +6,6 @@ namespace AssemblyAI
     {
         /// <summary>
         /// Get redacted audio<br/>
-        /// &lt;Warning&gt; Redacted audio creation is not supported on the EU endpoint. &lt;/Warning&gt;<br/>
         /// Retrieve the redacted audio object containing the status and URL to the redacted audio.
         /// </summary>
         /// <param name="transcriptId"></param>

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.GetRedactedAudio.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.GetRedactedAudio.g.cs
@@ -23,7 +23,6 @@ namespace AssemblyAI
 
         /// <summary>
         /// Get redacted audio<br/>
-        /// &lt;Warning&gt; Redacted audio creation is not supported on the EU endpoint. &lt;/Warning&gt;<br/>
         /// Retrieve the redacted audio object containing the status and URL to the redacted audio.
         /// </summary>
         /// <param name="transcriptId"></param>

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -554,7 +554,6 @@ paths:
         - transcript
       summary: Get redacted audio
       description: |
-        <Warning> Redacted audio creation is not supported on the EU endpoint. </Warning>
         Retrieve the redacted audio object containing the status and URL to the redacted audio.
       operationId: getRedactedAudio
       x-fern-sdk-group-name: transcripts


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the API documentation for the Get redacted audio endpoint (/v2/transcript/{transcript_id}/redacted-audio) by removing the previous warning about EU endpoint support.
  - Clarified the endpoint description without altering parameters, responses, or behavior.
  - No changes to the API surface or functionality; this is a documentation-only update to improve clarity for users reviewing the endpoint’s capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->