### PR TITLE
feat:EU server note for redacted audio; Keyterms prompt limits by model

### DIFF
--- a/src/libs/AssemblyAI/Generated/AssemblyAI.ITranscriptClient.GetRedactedAudio.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.ITranscriptClient.GetRedactedAudio.g.cs
@@ -6,6 +6,7 @@ namespace AssemblyAI
     {
         /// <summary>
         /// Get redacted audio<br/>
+        /// &lt;Note&gt;To retrieve the redacted audio on the EU server, replace `api.assemblyai.com` with `api.eu.assemblyai.com` in the `GET` request above.&lt;/Note&gt;<br/>
         /// Retrieve the redacted audio object containing the status and URL to the redacted audio.
         /// </summary>
         /// <param name="transcriptId"></param>

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.Models.Transcript.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.Models.Transcript.g.cs
@@ -171,7 +171,7 @@ namespace AssemblyAI
         public required global::System.Guid Id { get; set; }
 
         /// <summary>
-        /// Improve accuracy with up to 1000 domain-specific words or phrases (maximum 6 words per phrase).
+        /// Improve accuracy with up to 200 (for Universal) or 1000 (for Slam-1) domain-specific words or phrases (maximum 6 words per phrase).
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("keyterms_prompt")]
         public global::System.Collections.Generic.IList<string>? KeytermsPrompt { get; set; }
@@ -495,7 +495,7 @@ namespace AssemblyAI
         /// The unique identifier of your transcript
         /// </param>
         /// <param name="keytermsPrompt">
-        /// Improve accuracy with up to 1000 domain-specific words or phrases (maximum 6 words per phrase).
+        /// Improve accuracy with up to 200 (for Universal) or 1000 (for Slam-1) domain-specific words or phrases (maximum 6 words per phrase).
         /// </param>
         /// <param name="languageCode">
         /// The language of your audio file.<br/>

--- a/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.GetRedactedAudio.g.cs
+++ b/src/libs/AssemblyAI/Generated/AssemblyAI.TranscriptClient.GetRedactedAudio.g.cs
@@ -23,6 +23,7 @@ namespace AssemblyAI
 
         /// <summary>
         /// Get redacted audio<br/>
+        /// &lt;Note&gt;To retrieve the redacted audio on the EU server, replace `api.assemblyai.com` with `api.eu.assemblyai.com` in the `GET` request above.&lt;/Note&gt;<br/>
         /// Retrieve the redacted audio object containing the status and URL to the redacted audio.
         /// </summary>
         /// <param name="transcriptId"></param>

--- a/src/libs/AssemblyAI/openapi.yaml
+++ b/src/libs/AssemblyAI/openapi.yaml
@@ -554,6 +554,7 @@ paths:
         - transcript
       summary: Get redacted audio
       description: |
+        <Note>To retrieve the redacted audio on the EU server, replace `api.assemblyai.com` with `api.eu.assemblyai.com` in the `GET` request above.</Note>
         Retrieve the redacted audio object containing the status and URL to the redacted audio.
       operationId: getRedactedAudio
       x-fern-sdk-group-name: transcripts
@@ -2882,7 +2883,7 @@ components:
         keyterms_prompt:
           x-label: Keyterms prompt
           description: |
-            Improve accuracy with up to 1000 domain-specific words or phrases (maximum 6 words per phrase).
+            Improve accuracy with up to 200 (for Universal) or 1000 (for Slam-1) domain-specific words or phrases (maximum 6 words per phrase).
           type: array
           items:
             x-label: Keyterm


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added EU server guidance for the Get redacted audio endpoint, specifying api.eu.assemblyai.com for EU requests.
  * Revised Keyterms prompt description to reflect model-specific limits: 200 words for Universal and 1000 words for Slam-1, replacing the previous single 1000-word limit.
  * Clarified endpoint usage notes to help ensure correct configuration for EU-based usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->